### PR TITLE
Document remote Supabase access via Cloudflare Tunnel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,13 +112,23 @@ import time (`src/datasmith/__init__.py` → `dotenv.load_dotenv`), so reading
   `DATASMITH_RL_MAX_RETRIES`, `DATASMITH_NEIGHBOR_WINDOW_DAYS`,
   `DATASMITH_NEIGHBOR_CAP`.
 
-## Supabase (local)
+## Supabase
 
 fc-data uses a **local Supabase** instance for all persistent state. Connection details live in `tokens.env`:
 
 - `SUPABASE_URL=http://127.0.0.1:54321` (PostgREST API)
 - `SUPABASE_KEY=sb_secret_...` (service-role key)
 - Direct Postgres: `host=127.0.0.1 port=54322 dbname=postgres user=postgres password=postgres`
+
+### Remote access
+
+The Supabase PostgREST API is also available at `https://db.formulacode.org` via a Cloudflare Tunnel, protected by Cloudflare Access service tokens. To connect from a remote machine, set these in `tokens.env`:
+
+- `SUPABASE_URL=https://db.formulacode.org`
+- `DATASMITH_CF_ACCESS_CLIENT_ID` — Cloudflare Access service-token Client ID
+- `DATASMITH_CF_ACCESS_CLIENT_SECRET` — Cloudflare Access service-token Client Secret
+
+When both `DATASMITH_CF_ACCESS_*` vars are set, `get_client()` and `get_async_client()` in `utils/db.py` automatically inject the required headers. See `docs/guide/remote-access.md` for full setup instructions.
 
 ### Key tables
 

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ grafana-tunnel: ## Expose Grafana publicly via Cloudflare Tunnel
 
 .PHONY: db-tunnel
 db-tunnel: ## Expose Supabase PostgREST API via Cloudflare Tunnel (db.formulacode.org)
-	@cloudflared tunnel run datasmith-db
+	@cloudflared tunnel --config ~/.cloudflared/config-db.yml run datasmith-db
 
 
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -323,6 +323,16 @@ $ npx supabase stop               # stop all containers
 
 Studio is available at the URL printed by `supabase status` (default `http://127.0.0.1:54323`) — use it to browse tables, run SQL, and inspect data.
 
+#### Remote access
+
+To connect from a remote machine (without running Supabase locally), the PostgREST API is available at `https://db.formulacode.org` via a Cloudflare Tunnel. Add these to your `tokens.env`:
+```bash
+SUPABASE_URL=https://db.formulacode.org
+DATASMITH_CF_ACCESS_CLIENT_ID=your-cf-client-id
+DATASMITH_CF_ACCESS_CLIENT_SECRET=your-cf-client-secret
+```
+See the [Remote Access guide](docs/guide/remote-access.md) for full setup and credential provisioning.
+
 Running `preflight` ensures that all the variables are properly defined:
 ```bash
 $ python -m datasmith.preflight


### PR DESCRIPTION
## Summary
- Add remote access section to CLAUDE.md under Supabase docs
- Fix db-tunnel Makefile target to use explicit cloudflared config path
- Add remote access quick-start snippet to README

## Test plan
- [x] All 598 tests pass locally
- [ ] CI passes